### PR TITLE
Allow Got Customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Built because manipulating strings is a real pain.
   - [What is it?](#what-is-it)
     - [Motivation](#motivation)
   - [API](#api)
+    - [Option Object](#option-object)
     - [Returns](#returns)
   - [The JSON query format](#the-json-query-format)
     - [Description](#description)
@@ -144,19 +145,7 @@ gotQl.query(graphQLEndpoint, query, [options])
 
 **options**
 
-- Type: `object`
-- Description: The option object with the following properties.
-  - _errorStatusCode_: Default HTTP status code to be returned on error
-    - Type: `number`
-  - _headers_: Additional headers to be sent
-    - Type: `object`, in the form of `[headerName: string]: headerValue: string`
-
->**Note:** GotQL uses [`debug`](https://npmjs.com/package/debug) internally as default debugger, so you can set debug levels by setting the `DEBUG` environment variable. These are the current levels:
->
-> - `gotql:info`
-> - `gotql:errors`
-> - `gotql:parser`
-> - `gotql:runner`
+See [option object](#option-object) for more information.
 
 ---
 
@@ -178,14 +167,7 @@ gotQl.mutation(graphQLEndpoint, query, [options])
 
 **options**
 
-- Type: `object`
-- Description: The option object with the following properties.
-  - _debug_: Activates debug logging
-    - Type: `boolean`
-  - _errorStatusCode_: Default HTTP status code to be returned on error
-    - Type: `number`
-  - _headers_: Additional headers to be sent
-    - Type: `object`, in the form of `[headerName: string]: headerValue: string`
+See [option object](#option-object) for more information.
 
 ---
 
@@ -204,6 +186,26 @@ gotQl.parser(query, type)
 
 - Type: `string`
 - Description: Must be either `'query'` or `'mutation'`
+
+### Option Object
+
+Both `gotql.query` and `gotql.mutation` accept an optional user option object with the following API:
+
+- Type: `object`
+- Description: The option object with the following properties.
+  - _errorStatusCode_: Default HTTP status code to be returned on error
+    - Type: `number`
+  - _headers_: Additional headers to be sent
+    - Type: `object`, in the form of `[headerName: string]: headerValue: string`
+  - _gotInstance_: Customized Got instance to be used when calling the endpoint
+    - Type: `got`. Internally this will be called as `got.post(prependHttp(endPoint), gotPayload)`
+
+>**Note:** GotQL uses [`debug`](https://npmjs.com/package/debug) internally as default debugger, so you can set debug levels by setting the `DEBUG` environment variable. These are the current levels:
+>
+> - `gotql:info`
+> - `gotql:info:parser`
+> - `gotql:info:runner`
+> - `gotql:errors`
 
 ### Returns
 

--- a/src/modules/parser.ts
+++ b/src/modules/parser.ts
@@ -1,6 +1,6 @@
 import debug from 'debug'
 import { GotQL } from '../types/generics'
-import { ParserError } from '../errors/parserError'
+import { ParserError } from '../errors/ParserError'
 import { QueryType, QueryOperation, VariableObject, ArgObject } from '../types/QueryType'
 const shout = debug('gotql:errors')
 const info = debug('gotql:info:parser')

--- a/src/mutation.ts
+++ b/src/mutation.ts
@@ -1,8 +1,8 @@
 import got from 'got'
 import debug from 'debug'
 import { run } from './modules/runner'
-import { QueryType } from './types/QueryType'
 import { GotQL } from './types/generics'
+import { QueryType } from './types/QueryType'
 import { UserOptions } from './types/UserOptions'
 const info = debug('gotql:info')
 
@@ -16,6 +16,7 @@ const info = debug('gotql:info')
  * @return {Promise<any>} A response object containing all the data
  */
 export function mutation (endPoint: string, query: QueryType, options?: UserOptions): Promise<any> {
+  const client = options && options.gotInstance ? options.gotInstance : got
   info('Starting a new mutation')
-  return run(endPoint, query, GotQL.ExecutionType.MUTATION, got, options)
+  return run(endPoint, query, GotQL.ExecutionType.MUTATION, client, options)
 }

--- a/src/query.ts
+++ b/src/query.ts
@@ -15,6 +15,7 @@ const info = debug('gotql:info')
  * @return {Promise<any>} A response object containing all the data
  */
 export function query (endPoint: string, query: QueryType, options?: UserOptions): Promise<any> {
+  const client = options && options.gotInstance ? options.gotInstance : got
   info('Starting a new query')
-  return run(endPoint, query, GotQL.ExecutionType.QUERY, got, options)
+  return run(endPoint, query, GotQL.ExecutionType.QUERY, client, options)
 }

--- a/src/types/UserOptions.ts
+++ b/src/types/UserOptions.ts
@@ -1,3 +1,5 @@
+import got = require('got')
+
 /**
  * @typedef {object} userOpts User Options
  * @prop {boolean} debug Sets debug mode on/off
@@ -8,5 +10,6 @@ export type UserOptions = {
   errorStatusCode: number,
   headers: {
     [name: string]: string
-  }
+  },
+  gotInstance?: got.GotInstance
 }


### PR DESCRIPTION
Allow users to customize the Got instance to be used with the server call.

closes #17 