### PR TITLE
Allowing empty fields for mutations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,6 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.gitignore.io/api/node,macos,visualstudiocode,vim,windows,linux
+
+### Jetbrains ###
+.idea

--- a/src/modules/parser.ts
+++ b/src/modules/parser.ts
@@ -225,7 +225,7 @@ function checkArgs (argsList: QueryType['operation']['args'], operationArg: stri
  * @param {boolean} allowEmptyFields If 'true', empty fields are allowed (WARNING: this is not considered a good practice)
  * @return {string} Parsed operation query
  */
-function parseOperation (query: QueryType, allowEmptyFields: boolean): string {
+function parseOperation (query: QueryType, allowEmptyFields: boolean = false): string {
   let operation = query.operation
   const hasEmptyFields = !operation.fields || !operation.fields.length
   info('Parsing operation %s', operation.name)

--- a/src/modules/parser.ts
+++ b/src/modules/parser.ts
@@ -222,7 +222,7 @@ function checkArgs (argsList: QueryType['operation']['args'], operationArg: stri
 /**
  * Parses the operation bit of the query
  * @param {QueryType} query The JSON-Like query to be parsed
- * @param {boolean} allowEmptyFields If 'true', empty fields are allowed (which is not considered a good practice)
+ * @param {boolean} allowEmptyFields If 'true', empty fields are allowed (WARNING: this is not considered a good practice)
  * @return {string} Parsed operation query
  */
 function parseOperation (query: QueryType, allowEmptyFields: boolean): string {
@@ -232,7 +232,7 @@ function parseOperation (query: QueryType, allowEmptyFields: boolean): string {
   if (!operation.name) throw new Error(`name is required for graphQL operation`)
   if (hasEmptyFields && !allowEmptyFields) throw new Error(`field list is required for operation "${operation.name}"`)
 
-  if(hasEmptyFields) info('Hint: having no fields is not considered as a good practice')
+  if(hasEmptyFields) info('Hint: Returning no fields is not considered a good practice')
 
   try {
     let operationArgs = ''
@@ -266,10 +266,9 @@ export function parse (query: QueryType, type: GotQL.ExecutionType): string {
     if (!query.operation) throw new Error('a query must have at least one operation')
     if (!type) throw new Error('type must be either "query" or "mutation"')
 
-    let isMutation = type === 'mutation'
     let queryName = (query.name) ? `${query.name} ` : ''
     info('Defining name "%s"', queryName)
-    const parsedQuery = `${type.trim()} ${queryName}${getQueryVars(query.variables)}{ ${parseOperation(query, isMutation)} }`.trim()
+    const parsedQuery = `${type.trim()} ${queryName}${getQueryVars(query.variables)}{ ${parseOperation(query, type === GotQL.ExecutionType.MUTATION)} }`.trim()
     info('Parsed query: %s', parsedQuery)
     return parsedQuery
   } catch (error) {

--- a/tests/parser.test.js
+++ b/tests/parser.test.js
@@ -663,8 +663,7 @@ describe('Should return valid query string with no fields array defined in mutat
       args: {
         where: { id: { _eq: 0 } },
         _set: { name: null }
-      },
-      fields: []
+      }
     }
   }
 

--- a/tests/parser.test.js
+++ b/tests/parser.test.js
@@ -541,11 +541,11 @@ describe('Should allow for nested arguments in mutation or query operations (#28
         id: '1234',
         data: {
           name: 'foo',
-          status: 'bar',
-        },
+          status: 'bar'
+        }
       },
-      fields: ['test'],
-    },
+      fields: ['test']
+    }
   }
 
   const queryReturn = 'query { updateSomething(id: "1234", data: { name: "foo", status: "bar" }) { test } }'
@@ -563,10 +563,10 @@ describe('Should allow numbers and other types in mutation args (#33)', (assert)
       name: 'updateSomething',
       args: {
         where: { id: { _eq: 0 } },
-        _set: { name: 'test' },
+        _set: { name: 'test' }
       },
-      fields: ['affected_rows'],
-    },
+      fields: ['affected_rows']
+    }
   }
 
   const queryReturn = 'query { updateSomething(where: { id: { _eq: "0" } }, _set: { name: "test" }) { affected_rows } }'
@@ -584,10 +584,10 @@ describe('Should allow null in mutation args (#33)', (assert) => {
       name: 'updateSomething',
       args: {
         where: { id: { _eq: 0 } },
-        _set: { name: null },
+        _set: { name: null }
       },
-      fields: ['affected_rows'],
-    },
+      fields: ['affected_rows']
+    }
   }
 
   const queryReturn = 'query { updateSomething(where: { id: { _eq: "0" } }, _set: { name: null }) { affected_rows } }'
@@ -604,9 +604,9 @@ describe('Should pass on arrays as arrays (#35)', (assert) => {
     operation: {
       name: 'insert_example',
       args: {
-        on_conflict: { update_columns: ['status', 'price'] },
+        on_conflict: { update_columns: ['status', 'price'] }
       },
-      fields: ['affected_rows'],
+      fields: ['affected_rows']
     }
   }
 
@@ -625,10 +625,10 @@ describe('Should throw an error on empty fields array in query (#36)', (assert) 
       name: 'updateSomething',
       args: {
         where: { id: { _eq: 0 } },
-        _set: { name: null },
+        _set: { name: null }
       },
-      fields: [],
-    },
+      fields: []
+    }
   }
 
   try {
@@ -637,9 +637,7 @@ describe('Should throw an error on empty fields array in query (#36)', (assert) 
     assert.is(error.message, 'Parse error: field list is required for operation "updateSomething"')
     assert.deepEqual(error.name, 'Error')
   }
-
 })
-
 
 describe('Should return valid query string with empty fields array in mutation (#37)', (assert) => {
   const query = {
@@ -647,10 +645,10 @@ describe('Should return valid query string with empty fields array in mutation (
       name: 'updateSomething',
       args: {
         where: { id: { _eq: 0 } },
-        _set: { name: null },
+        _set: { name: null }
       },
-      fields: [],
-    },
+      fields: []
+    }
   }
 
   const mutationReturn = 'mutation { updateSomething(where: { id: { _eq: "0" } }, _set: { name: null }) }'
@@ -664,10 +662,10 @@ describe('Should return valid query string with no fields array defined in mutat
       name: 'updateSomething',
       args: {
         where: { id: { _eq: 0 } },
-        _set: { name: null },
+        _set: { name: null }
       },
-      fields: [],
-    },
+      fields: []
+    }
   }
 
   const mutationReturn = 'mutation { updateSomething(where: { id: { _eq: "0" } }, _set: { name: null }) }'

--- a/tests/parser.test.js
+++ b/tests/parser.test.js
@@ -618,3 +618,59 @@ describe('Should pass on arrays as arrays (#35)', (assert) => {
   const mutationResult = parse(query, 'mutation')
   assert.deepEqual(mutationResult, mutationReturn)
 })
+
+describe('Should throw an error on empty fields array in query (#36)', (assert) => {
+  const query = {
+    operation: {
+      name: 'updateSomething',
+      args: {
+        where: { id: { _eq: 0 } },
+        _set: { name: null },
+      },
+      fields: [],
+    },
+  }
+
+  try {
+    parse(query, 'query')
+  } catch (error) {
+    assert.is(error.message, 'Parse error: field list is required for operation "updateSomething"')
+    assert.deepEqual(error.name, 'Error')
+  }
+
+})
+
+
+describe('Should return valid query string with empty fields array in mutation (#37)', (assert) => {
+  const query = {
+    operation: {
+      name: 'updateSomething',
+      args: {
+        where: { id: { _eq: 0 } },
+        _set: { name: null },
+      },
+      fields: [],
+    },
+  }
+
+  const mutationReturn = 'mutation { updateSomething(where: { id: { _eq: "0" } }, _set: { name: null }) }'
+  const mutationResult = parse(query, 'mutation')
+  assert.deepEqual(mutationResult, mutationReturn)
+})
+
+describe('Should return valid query string with no fields array defined in mutation (#38)', (assert) => {
+  const query = {
+    operation: {
+      name: 'updateSomething',
+      args: {
+        where: { id: { _eq: 0 } },
+        _set: { name: null },
+      },
+      fields: [],
+    },
+  }
+
+  const mutationReturn = 'mutation { updateSomething(where: { id: { _eq: "0" } }, _set: { name: null }) }'
+  const mutationResult = parse(query, 'mutation')
+  assert.deepEqual(mutationResult, mutationReturn)
+})


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Empty fields arrays create a syntactically incorrect GraphQL expression, which is totally valid for 'query' operations, but not for 'mutation'. This PR checks for empty arrays of a query and eventually throws an error (leading to a slightly more consistent behavior), and furthermore allows mutations with empty/void return values. Although, the latter is not considered as best practice, it makes gotql usable for situations where such best practice is not applied.

(see #39)

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

Alternatively, a specific `void` flag was proposed, but I thought the current solution has a bit less overhead in terms of implement, as no additional parameter needs to be introduced. From the perspective of developer experience, the _implicit_ option is much more intuitive and has less cognitive overhead.

### Benefits

<!-- What benefits will be realized by the code change? Note: this should benefit most users and not a single problem -->
This PR makes this very useful (and well written) lib even more robust.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
Allowing mutations without return values breaks with nowadays best practices (that's why I added an informative hint about godd practices)

### Applicable Issues

<!-- Enter any applicable Issues here -->

see #39 
