### PR TITLE
Feature Tagged Template 'literal'

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,22 @@ const query = {
 }
 ```
 
+Or with shorthand tagged template string:
+
+```js
+const { literal } = require('gotql')
+
+const query = {
+  operation: {
+    name: 'user',
+    args: {
+      type: literal`internal`
+    },
+    fields: ['name', 'age']
+  }
+}
+```
+
 Outputs:
 
 ```js

--- a/src/helpers/literal.ts
+++ b/src/helpers/literal.ts
@@ -10,6 +10,5 @@ import { LiteralObject } from '../types/Literal'
  * @return {LiteralObject} LiteralObject
  */
 export function literal(literalValue: TemplateStringsArray): LiteralObject {
-  if (!literalValue || !literalValue[0]) throw new Error('literalValue cannot be null or empty')
-  return { value: literalValue[0], escape: false }
+  return { value: literalValue[0] || '', escape: false }
 }

--- a/src/helpers/literal.ts
+++ b/src/helpers/literal.ts
@@ -10,5 +10,5 @@ import { LiteralObject } from '../types/Literal'
  * @return {LiteralObject} LiteralObject
  */
 export function literal(literalValue: TemplateStringsArray): LiteralObject {
-  return { value: literalValue[0] || '', escape: false }
+  return { value: literalValue && literalValue[0] || '', escape: false }
 }

--- a/src/helpers/literal.ts
+++ b/src/helpers/literal.ts
@@ -1,0 +1,15 @@
+import { LiteralObject } from '../types/Literal'
+
+/**
+ * Literal is a tagged template for an object { value: string, escape: false }
+ * @example
+ * // literal`example_pkey` return { value: 'example_pkey', escape: false }
+ * @example
+ * // literal`['example_key01', 'example_key02']` return { value: '['example_key01', 'example_key02']', escape: false }
+ * @param {TemplateStringsArray} literalValue Literal value
+ * @return {LiteralObject} LiteralObject
+ */
+export const literal = (literalValue: TemplateStringsArray): LiteralObject => {
+  if (!literalValue || !literalValue[0]) throw new Error('literalValue cannot be null or empty')
+  return { value: literalValue[0], escape: false }
+}

--- a/src/helpers/literal.ts
+++ b/src/helpers/literal.ts
@@ -9,7 +9,7 @@ import { LiteralObject } from '../types/Literal'
  * @param {TemplateStringsArray} literalValue Literal value
  * @return {LiteralObject} LiteralObject
  */
-export const literal = (literalValue: TemplateStringsArray): LiteralObject => {
+export function literal(literalValue: TemplateStringsArray): LiteralObject {
   if (!literalValue || !literalValue[0]) throw new Error('literalValue cannot be null or empty')
   return { value: literalValue[0], escape: false }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { query } from './query'
 import { mutation } from './mutation'
 import { parse as parser } from './modules/parser'
+import { literal } from './helpers/literal'
 
-module.exports = { query, mutation, parser }
-export { query, mutation, parser }
+module.exports = { query, mutation, parser, literal }
+export { query, mutation, parser, literal }

--- a/src/types/Literal.ts
+++ b/src/types/Literal.ts
@@ -1,0 +1,4 @@
+export type LiteralObject = {
+  value: string
+  escape: boolean
+}

--- a/tests/helpers/literal.test.ts
+++ b/tests/helpers/literal.test.ts
@@ -1,0 +1,29 @@
+import { literal } from '../../src/helpers/literal'
+import { LiteralObject } from '../../src/types/Literal'
+
+describe('literal', () => {
+  it('Should return an object with value and escape properties', () => {
+    const expectedResult: LiteralObject = { value: 'field_test', escape: false }
+
+    const literalResult = literal`field_test`
+
+    expect(literalResult).toEqual(expectedResult)
+  })
+
+  it('Should return an object with value and escape properties, keeping the array informed in the literal', () => {
+    const expectedResult: LiteralObject = { value: "['field01','field01']", escape: false }
+
+    const literalResult = literal`['field01','field01']`
+
+    expect(literalResult).toEqual(expectedResult)
+  })
+
+  it('should return an error when the argument is empty', () => {
+    expect(() => literal``).toThrowError('literalValue cannot be null or empty')
+  })
+
+  it('should return an error when the argument is null', () => {
+    const nullValue = null as unknown as TemplateStringsArray
+    expect(() => literal(nullValue)).toThrowError('literalValue cannot be null or empty')
+  })
+})

--- a/tests/helpers/literal.test.ts
+++ b/tests/helpers/literal.test.ts
@@ -18,12 +18,21 @@ describe('literal', () => {
     expect(literalResult).toEqual(expectedResult)
   })
 
-  it('should return an error when the argument is empty', () => {
-    expect(() => literal``).toThrowError('literalValue cannot be null or empty')
+  it('should return an object with an empty value property, when literal is called with empty arguments', () => {
+    const expectedResult: LiteralObject = { value: '', escape: false }
+
+    const literalResult = literal``
+
+    expect(literalResult).toEqual(expectedResult)
   })
 
-  it('should return an error when the argument is null', () => {
+  it('should return an object with an empty value property, when the literal is called with a null argument', () => {
+    const expectedResult: LiteralObject = { value: '', escape: false }
+
     const nullValue = null as unknown as TemplateStringsArray
-    expect(() => literal(nullValue)).toThrowError('literalValue cannot be null or empty')
+
+    const literalResult = literal(nullValue)
+
+    expect(literalResult).toEqual(expectedResult)
   })
 })


### PR DESCRIPTION
<!-- 
Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions 
-->
### Description of the Change
Issue -> #40 
With this modification, a function named 'literal' was added, which is nothing more than an abbreviation for the 
```js
{ value: string, escape: false }
```
Where we can use it as follows.
```js
literal`example_pkey` // return { value: 'example_pkey', escape: false }
```

The test of this function was written in typescript, aiming to close this PR here #46 

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Benefits
Shortens the object that needs to be used literally
<!-- What benefits will be realized by the code change? Note: this should benefit most users and not a single problem -->

### Applicable Issues
 #40 
<!-- Enter any applicable Issues here -->
