### PR TITLE
Support Int type arguments

### DIFF
--- a/src/modules/parser.ts
+++ b/src/modules/parser.ts
@@ -193,6 +193,7 @@ function checkArgs (argsList: QueryType['operation']['args'], operationArg: stri
   const argValue = argsList![operationArg]
   info(`Obtained arg value of %O for %s`, argValue, operationArg)
   if (isNull(argValue)) return 'null' // Check for strict null values (#33)
+  if (typeof argValue === 'number') return argValue // Support Int type arguments (#74)
   if (isArray(argValue)) {
     const parsedArray = (argValue as unknown as Array<any>).map((item: any) => {
       const returnByType: Record<string, any> = {


### PR DESCRIPTION

### Description of the Change

Pass numbers through without turning them into strings.

### Why Should This Be here?

Otherwise, APIs that expect number arguments throw an error. 

### Benefits

Anyone who wants to use an API that takes numerical arguments can now do that. 

### Possible Drawbacks

Code that relied on the coercion of numbers to strings that calls an API that requires a string will now fail.

### Applicable Issues

#74 
