### PR TITLE
added support for array args with more than one item

### DIFF
--- a/src/modules/parser.ts
+++ b/src/modules/parser.ts
@@ -180,6 +180,11 @@ function parseNestedArgument (nestedArgList: QueryType['operation']['args'], var
   return parsedFinalString
 }
 
+function parseArgsArray(item: any, variables: QueryType['variables'] ) {
+  const parsedArray = Object.keys(item).map(key => ` ${key}: ${checkArgs(item, key, variables)} `)
+  return `{${parsedArray.join(',')}}`
+}
+
 /**
  * Checks if the operation argument is a variable or not
  *
@@ -196,7 +201,7 @@ function checkArgs (argsList: QueryType['operation']['args'], operationArg: stri
   if (isArray(argValue)) {
     const parsedArray = (argValue as unknown as Array<any>).map((item: any) => {
       const returnByType: Record<string, any> = {
-        object: (item: any) => `{ ${Object.keys(item)[ 0 ]}: ${checkArgs(item, Object.keys(item)[ 0 ], variables)} }`,
+        object: (item: any) => parseArgsArray(item, variables),
         string: (item: any) => `"${item}"`
       }
 

--- a/src/types/QueryType.ts
+++ b/src/types/QueryType.ts
@@ -35,7 +35,7 @@ type OneOrMore<T> = T | T[]
 
 export type ArgObject = {
   [name: string]: OneOrMore<ArgObject | Primitive>
-} | LiteralObject
+} | LiteralObject | Array<ArgObject | Primitive>
 
 /**
  * @typedef {object} fieldObj Field properties

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -2,6 +2,7 @@ import { parse } from '../src/modules/parser'
 import { GotQL } from '../src/types/generics'
 import { QueryType } from '../src/types/QueryType'
 import ExecutionType = GotQL.ExecutionType
+import { literal } from '../src'
 
 describe('parser', () => {
   it('Should return a usable simple query', () => {
@@ -739,5 +740,41 @@ describe('parser', () => {
     const testReturn = 'query TestQuery ($testVar: Boolean) { TestOp { field1 field2 } }'
     const queryResult = parse((query as unknown) as QueryType, ExecutionType.QUERY)
     expect(queryResult).toEqual(testReturn)
+  })
+
+  it('Should enable working with array args that have more than one item', () => {
+    const query = {
+      operation: {
+        name: 'productCreate',
+        args: {
+          media: [
+            {
+              originalSource:
+                'https://example.com/image.jpg',
+              mediaContentType: literal`IMAGE`,
+            },
+            {
+              originalSource:
+                'https://example.com/image_2.jpg',
+              mediaContentType: literal`IMAGE`,
+            },
+          ],
+        },
+        fields: [
+          {
+            product: {
+              fields: ['createdAt', 'title'],
+            },
+            userErrors: {
+              fields: ['field', 'message'],
+            },
+          },
+        ],
+      },
+    }
+
+    const mutationResult = parse(query, ExecutionType.MUTATION)
+    const expectedResult = 'mutation { productCreate(media: [{ originalSource: "https://example.com/image.jpg" , mediaContentType: IMAGE },{ originalSource: "https://example.com/image_2.jpg" , mediaContentType: IMAGE }]) { product { createdAt title } } }'
+    expect(mutationResult).toEqual(expectedResult)
   })
 })


### PR DESCRIPTION
<!-- 
### Description of the Change
Added support for array arguments containing multiple items. Previously, when parsing arrays with more than one item, only the first key-value pair of each item was retained in the output. This resulted in incomplete or incorrect query generation, which limited functionality and caused unexpected behavior.

### Why Should This Be here?
Handling array arguments correctly is a fundamental aspect of GraphQL and a critical feature for any GraphQL library. This enhancement addresses a missing core functionality that I noticed in this otherwise excellent library. By adding support for multi-item arrays, the library now aligns more closely with GraphQL's standard behavior and expectations.

### Benefits
This change significantly improves convenience and usability when working with array arguments in functions. Developers can now work seamlessly with arrays that have multiple items, ensuring correct query generation and reducing the potential for errors.

For example, with this fix, array arguments like the following:
```javascript
media: [
  {
    originalSource: 'https://example.com/image.jpg',
    mediaContentType: literal`IMAGE`,
  },
  {
    originalSource: 'https://example.com/image_2.jpg',
    mediaContentType: literal`IMAGE`,
  },
]
```
will now produce the correct query output.

### The bug
Previously, the library failed to handle arrays with multiple items. When parsing such queries, only the first key-value pair from each object in the array was retained, leading to incomplete results.

Example:
Input Query:
```javascript
const query = {
  operation: {
    name: 'productCreate',
    args: {
      media: [
        {
          originalSource: 'https://example.com/image.jpg',
          mediaContentType: literal`IMAGE`,
        },
        {
          originalSource: 'https://example.com/image_2.jpg',
          mediaContentType: literal`IMAGE`,
        },
      ],
    },
    fields: [
      {
        product: {
          fields: ['createdAt', 'title'],
        },
        userErrors: {
          fields: ['field', 'message'],
        },
      },
    ],
  },
};
```

Expected Result:
```
mutation {
  productCreate(media: [
    { originalSource: "https://example.com/image.jpg", mediaContentType: IMAGE },
    { originalSource: "https://example.com/image_2.jpg", mediaContentType: IMAGE }
  ]) {
    product {
      createdAt
      title
    }
  }
}
```

Actual Result before:
```
mutation {
  productCreate(media: [
    { originalSource: "https://example.com/image.jpg" },
    { originalSource: "https://example.com/image_2.jpg" }
  ]) {
    product {
      createdAt
      title
    }
  }
}
```
